### PR TITLE
Add IPFS service

### DIFF
--- a/app/services/ipfs.js
+++ b/app/services/ipfs.js
@@ -12,7 +12,6 @@ export default Ember.Service.extend({
     }
     let ipfs = ipfsAPI(config.ipfs);
     this.set('ipfsInstance', ipfs);
-    window.ipfs = ipfs;
     return ipfs;
   }.property('ipfsInstance'),
 

--- a/app/services/ipfs.js
+++ b/app/services/ipfs.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import ipfsAPI from 'npm:ipfs-api';
+import config from 'kredits-web/config/environment';
+
+export default Ember.Service.extend({
+
+  ipfsInstance: null,
+
+  ipfs: function() {
+    if (this.get('ipfsInstance')) {
+      return this.get('ipfsInstance');
+    }
+    let ipfs = ipfsAPI(config.ipfs);
+    this.set('ipfsInstance', ipfs);
+    window.ipfs = ipfs;
+    return ipfs;
+  }.property('ipfsInstance'),
+
+  storeFile(content) {
+    let ipfs = this.get('ipfs');
+    return ipfs.add(new ipfs.Buffer(content)).then((res) => {
+      return res[0].hash;
+    });
+  },
+
+  getFile(hash) {
+    return this.get('ipfs').cat(hash, { buffer: true }, (err, res) => {
+      return res.toString();
+    });
+  }
+
+});

--- a/app/services/ipfs.js
+++ b/app/services/ipfs.js
@@ -17,13 +17,13 @@ export default Ember.Service.extend({
 
   storeFile(content) {
     let ipfs = this.get('ipfs');
-    return ipfs.add(new ipfs.Buffer(content)).then((res) => {
+    return ipfs.add(new ipfs.Buffer(content)).then(res => {
       return res[0].hash;
     });
   },
 
   getFile(hash) {
-    return this.get('ipfs').cat(hash, { buffer: true }).then(res) => {
+    return this.get('ipfs').cat(hash, { buffer: true }).then(res => {
       return res.toString();
     });
   }

--- a/app/services/ipfs.js
+++ b/app/services/ipfs.js
@@ -23,7 +23,7 @@ export default Ember.Service.extend({
   },
 
   getFile(hash) {
-    return this.get('ipfs').cat(hash, { buffer: true }, (err, res) => {
+    return this.get('ipfs').cat(hash, { buffer: true }).then(res) => {
       return res.toString();
     });
   }

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -7,6 +7,8 @@ import kreditsContracts from 'npm:kredits-contracts';
 
 export default Ember.Service.extend({
 
+  ipfs: Ember.inject.service(),
+
   web3Instance: null,
   web3Provided: false, // Web3 provided (using Mist Browser, Metamask et al.)
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -22,7 +22,12 @@ module.exports = function(environment) {
     },
 
     web3ProviderUrl: "https://parity.kosmos.org:8545",
-    ethereumChain: "testnet"
+    ethereumChain: "testnet",
+    ipfs: {
+      host: 'localhost',
+      port: '5001',
+      protocol: 'http'
+    }
   };
 
   if (environment === 'development') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -21,6 +21,15 @@ module.exports = function(environment) {
       // when it is created
     },
 
+    browserify: {
+      transform: [
+        ["babelify", {
+          presets: ["es2015"],
+          global: true
+        }]
+      ]
+    },
+
     web3ProviderUrl: "https://parity.kosmos.org:8545",
     ethereumChain: "testnet",
     ipfs: {

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ipfs-api": "^12.1.7",
+    "kredits-contracts": "67P/kredits-contracts",
     "loader.js": "^4.0.10",
-    "web3": "^0.18.2",
-    "kredits-contracts": "67P/kredits-contracts"
+    "web3": "^0.18.2"
   },
   "engines": {
     "node": ">= 0.12.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "deploy": "npm run build-prod && npm run update-version-file && bash scripts/deploy.sh"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.22.0",
+    "babelify": "^7.3.0",
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
     "ember-browserify": "^1.1.13",

--- a/tests/unit/services/ipfs-test.js
+++ b/tests/unit/services/ipfs-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:ipfs', 'Unit | Service | ipfs', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Add the `ipfs-api` JS library and a service using the browserified version of it. The service has functions for storing and reading file contests.

Unfortunately, there's some ES6 breaking in PhantomJS again, this time from some dependency of the new IPFS lib.