### PR TITLE
Add support to locally conifgure web3 provider

### DIFF
--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -25,7 +25,8 @@ export default Ember.Service.extend({
       this.set('web3Provided', true);
     } else {
       Ember.Logger.debug('[kredits] Creating new instance from npm module class');
-      let provider = new Web3.providers.HttpProvider(config.web3ProviderUrl);
+      let providerUrl = localStorage.getItem('config:web3ProviderUrl') || config.web3ProviderUrl;
+      let provider = new Web3.providers.HttpProvider(providerUrl);
       web3Instance = new Web3(provider);
     }
 


### PR DESCRIPTION
If no web3 is provided from the browser we check if a
config:web3ProviderUrl item is set in localstorage.
If yes we connect to that provider otherwise use the default config.
Helpful for working simultanously with different chains and providers.