### PR TITLE
Block in application route if accountNeedsUnlock

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,4 +1,18 @@
-import Ember from 'ember';
+import injectService from 'ember-service/inject';
+import Route from 'ember-route';
 
-export default Ember.Route.extend({
+export default Route.extend({
+  kredits: injectService(),
+
+  beforeModel(transition) {
+    const kredits = this.get('kredits');
+
+    return kredits.initEthProvider().then(() => {
+      if (kredits.get('accountNeedsUnlock')) {
+        if (confirm('It looks like you have an Ethereum wallet available. Please unlock your account.')) {
+          transition.retry();
+        }
+      }
+    });
+  },
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -4,17 +4,6 @@ export default Ember.Route.extend({
 
   kredits: Ember.inject.service(),
 
-  beforeModel(transition) {
-    const kredits = this.get('kredits');
-    return kredits.initEthProvider().then(() => {
-      if (kredits.get('accountNeedsUnlock')) {
-        if (confirm('It looks like you have an Ethereum wallet available. Please unlock your account.')) {
-          transition.retry();
-        }
-      }
-    });
-  },
-
   model() {
     let newContributor = Ember.getOwner(this).lookup('model:contributor');
     newContributor.set('kind', 'person');


### PR DESCRIPTION
The index route never gets invoked if you reload on the proposal page. That change makes sure we always initialize `ethProvider`.