### PR TITLE
Fix proposal loading

### DIFF
--- a/app/lib/kredits/contracts/operator.js
+++ b/app/lib/kredits/contracts/operator.js
@@ -13,7 +13,7 @@ export default class Operator extends Base {
         count = count.toNumber();
         let proposals = [];
 
-        for (let id = 0; id < count; id++) {
+        for (let id = 1; id <= count; id++) {
           proposals.push(this.getById(id));
         }
 


### PR DESCRIPTION
we changed the storage of proposals from an array to a mapping.
Because of this keys/ids now no longer start with zero but with 1.