### PR TITLE
[WIP] Use infura hosted provider if web3 is not available

### DIFF
--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -38,28 +38,20 @@ export default Service.extend({
         );
         ethProvider.listAccounts().then((accounts) => {
           this.set('currentUserAccounts', accounts);
-          resolve(ethProvider);
+          resolve(ethProvider, ethProvider.getSigner());
         });
       } else {
         console.debug('[kredits] Creating new instance from npm module class');
         networkId = parseInt(config.contractMetadata.networkId);
-        ethProvider = new ethers.providers.JsonRpcProvider(
-          config.web3ProviderUrl,
-          { chainId: networkId }
-        );
-        resolve(ethProvider);
+        console.log(networkId)
+        ethProvider = new ethers.providers.InfuraProvider({ chainId: networkId, name: 'kovan' });
+        resolve(ethProvider, null);
       }
     });
   },
 
   setup() {
-    return this.getEthProvider().then((ethProvider) => {
-      let ethSigner;
-
-      if (ethProvider.getSigner) {
-        ethSigner = ethProvider.getSigner();
-      }
-
+    return this.getEthProvider().then((ethProvider, ethSigner) => {
       let kredits = new Kredits(ethProvider, ethSigner);
       return kredits
         .init()

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -29,6 +29,7 @@ export default Service.extend({
     return new RSVP.Promise((resolve) => {
       let ethProvider;
       let networkId;
+      let networkName;
       if (typeof window.web3 !== 'undefined') {
         console.debug('[kredits] Using user-provided instance, e.g. from Mist browser or Metamask');
         networkId = parseInt(window.web3.version.network);
@@ -43,8 +44,9 @@ export default Service.extend({
       } else {
         console.debug('[kredits] Creating new instance from npm module class');
         networkId = parseInt(config.contractMetadata.networkId);
-        console.log(networkId)
-        ethProvider = new ethers.providers.InfuraProvider({ chainId: networkId, name: 'kovan' });
+        networkName = config.contractMetadata.networkName;
+        console.log(networkName);
+        ethProvider = new ethers.providers.InfuraProvider({ chainId: networkId, name: networkName });
         resolve(ethProvider, null);
       }
     });

--- a/config/environment.js
+++ b/config/environment.js
@@ -35,7 +35,7 @@ module.exports = function(environment) {
       ]
     },
 
-    contractMetadata: { networkId: '42' },
+    contractMetadata: { networkId: '42', networkName: 'kovan' },
 
     web3ProviderUrl: 'https://parity.kosmos.org:8545',
 
@@ -80,6 +80,9 @@ module.exports = function(environment) {
 
   if (process.env.NETWORK_ID) {
     ENV.contractMetadata['networkId'] = process.env.NETWORK_ID;
+  }
+  if (process.env.NETWORK_NAME) {
+    ENV.contractMetadata['networkName'] = process.env.NETWORK_NAME;
   }
   if (process.env.WEB3_PROVIDER_URL) {
     ENV.web3ProviderUrl = process.env.WEB3_PROVIDER_URL;


### PR DESCRIPTION
If the user does not have metamask or similar (no web3 provider is
availale) we will load data from the infura node.

No signer is available for the infura node but the ethers provider would
throw an error if we try to access it - so this moves the decision of
choosing the provider to the ethProvider function.