### PR TITLE
Remove default contributors value in propsal component

### DIFF
--- a/app/components/add-proposal/component.js
+++ b/app/components/add-proposal/component.js
@@ -5,7 +5,7 @@ import { and, notEmpty } from '@ember/object/computed';
 export default Component.extend({
 
   attributes: null,
-  contributors: null,
+  contributors: Object.freeze([]),
 
   isValidContributor: notEmpty('contributorId'),
   isValidAmount: computed('amount', function() {

--- a/app/components/add-proposal/component.js
+++ b/app/components/add-proposal/component.js
@@ -28,8 +28,6 @@ export default Component.extend({
       description: null,
       url: null,
     });
-
-    this.set('contributors', []);
   },
 
   didInsertElement() {


### PR DESCRIPTION
It seems that this somehow prevents/overwrites the contributors which actually should be loaded in the controller.

Before that the contributors dropdown on the proposals new page was empty. This change seems to fix it.