### PR TITLE
Don't include vetoed contributions in graph

### DIFF
--- a/app/components/chart-contributions-by-type/component.js
+++ b/app/components/chart-contributions-by-type/component.js
@@ -20,9 +20,11 @@ export default Component.extend({
 
   chartData: computed('contributions', function() {
     let kredits = this.contributions
+                      .filterBy('vetoed', false)
                       .map(c => {
                         return { kind: c.kind, amount: c.amount }
-                      }).reduce(function (kinds, c) {
+                      })
+                      .reduce(function (kinds, c) {
                         if (c.kind in kinds) {
                           kinds[c.kind] = kinds[c.kind] + c.amount
                         } else {

--- a/tests/unit/components/chart-contributions-by-type-test.js
+++ b/tests/unit/components/chart-contributions-by-type-test.js
@@ -4,22 +4,22 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Component | chart-contributions-by-type', function(hooks) {
   setupTest(hooks);
 
-  let proposals = [
-    { kind: 'dev', amount: 500 },
-    { kind: 'dev', amount: 1500 },
-    { kind: 'ops', amount: 1500 },
-    { kind: 'design', amount: 5000 },
-    { kind: 'ops', amount: 1500 },
-    { kind: 'dev', amount: 5000 },
-    { kind: 'community', amount: 5000 },
-    { kind: 'docs', amount: 500 },
-    { kind: 'docs', amount: 500 },
-    { kind: 'docs', amount: 500 },
+  let contributions = [
+    { kind: 'dev'       , amount: 500  , vetoed: true },
+    { kind: 'dev'       , amount: 1500 , vetoed: false },
+    { kind: 'ops'       , amount: 1500 , vetoed: false },
+    { kind: 'design'    , amount: 5000 , vetoed: false },
+    { kind: 'ops'       , amount: 1500 , vetoed: false },
+    { kind: 'dev'       , amount: 5000 , vetoed: false },
+    { kind: 'community' , amount: 5000 , vetoed: false },
+    { kind: 'docs'      , amount: 500  , vetoed: true },
+    { kind: 'docs'      , amount: 500  , vetoed: false },
+    { kind: 'docs'      , amount: 500  , vetoed: false }
   ];
 
   test('#chartData', function(assert) {
     let component = this.owner.factoryFor('component:chart-contributions-by-type').create();
-    component.set('contributions', proposals);
+    component.set('contributions', contributions);
 
     let data = component.get('chartData');
 
@@ -30,7 +30,7 @@ module('Unit | Component | chart-contributions-by-type', function(hooks) {
     );
     assert.deepEqual(
       data.datasets[0].data,
-      [5000, 5000, 7000, 3000, 1500],
+      [5000, 5000, 6500, 3000, 1000],
       'returns the correct kredit sums'
     );
   });


### PR DESCRIPTION
Currently, kredits from vetoed contributions are counted in the graph data.