### PR TITLE
Fix template syntax error

### DIFF
--- a/app/components/add-contribution/template.hbs
+++ b/app/components/add-contribution/template.hbs
@@ -15,7 +15,7 @@
       <option value="dev" selected={{eq kind "dev"}}>Development</option>
       <option value="docs" selected={{eq kind "docs"}}>Documentation</option>
       <option value="ops" selected={{eq kind "ops"}}>IT Operations</option>
-      <option value="special" selected={{eq kind "ops"}}>Special</option>
+      <option value="special" selected={{eq kind "special"}}>Special</option>
     </select>
   </p>
   <p>


### PR DESCRIPTION
Wasn't able to select the "special" contribution kind, due to it being bound to the wrong property.

fixes #125