### PR TITLE
Use generic contributor name in new contribution form

### DIFF
--- a/app/components/add-contribution/template.hbs
+++ b/app/components/add-contribution/template.hbs
@@ -3,7 +3,7 @@
     <select required onchange={{action (mut contributorId) value="target.value"}}>
       <option value="" selected disabled hidden>Contributor</option>
       {{#each contributors as |contributor|}}
-        <option value={{contributor.id}} selected={{eq contributorId contributor.id}}>{{contributor.github_username}}</option>
+        <option value={{contributor.id}} selected={{eq contributorId contributor.id}}>{{contributor.name}}</option>
       {{/each}}
     </select>
   </p>


### PR DESCRIPTION
Use the generic name instead of the Github username.