### PR TITLE
Sort contributions by date instead of ID

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -11,7 +11,7 @@ export default Controller.extend({
   contributionsConfirmed: alias('kredits.contributionsConfirmed'),
   contributionsUnconfirmed: alias('kredits.contributionsUnconfirmed'),
 
-  contributionsSorting: Object.freeze(['id:desc']),
+  contributionsSorting: Object.freeze(['date:desc', 'time:desc', 'id:desc']),
   contributionsUnconfirmedSorted: sort('contributionsUnconfirmed', 'contributionsSorting'),
   contributionsConfirmedSorted: sort('contributionsConfirmed', 'contributionsSorting'),
 


### PR DESCRIPTION
This changes the sorting to sort first by date and time, and only then by ID.

refs #121