### PR TITLE
Ensure share repo is updated when versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build-prod": "rm -rf release/* && ember build -prod --output-path release",
     "preversion": "npm test",
     "version": "npm run build-prod && git add release/",
+    "postversion": "git push origin master",
     "deploy": "git push 5apps master"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, it's easy to forget manually pushing to master after versioning/building. In which case things can be merged remotely, and when pulling with rebase the version commit ends up being changed and behind what was actually tagged.

This adds a postversion script which simply pushes to the remote automatically after the version commit and tag have been added by npm.