### PR TITLE
Use local default IPFS gateway

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -56,7 +56,8 @@ module.exports = function(environment) {
     ENV.ipfs = {
       host: 'localhost',
       port: '5001',
-      protocol: 'http'
+      protocol: 'http',
+      gatewayUrl: 'http://localhost:8080/ipfs'
     };
   }
 


### PR DESCRIPTION
Same as for ipfs.kosmos.org, this turns document fetches into GET requests, which will be cached.