### PR TITLE
Mark contributor in list as selected when opening details

### DIFF
--- a/app/components/contributor-list/component.js
+++ b/app/components/contributor-list/component.js
@@ -7,7 +7,7 @@ export default Component.extend({
 
   tagName: 'table',
   classNames: 'contributor-list',
-  selectedContributor: null,
+  selectedContributorId: null,
 
   actions: {
 

--- a/app/components/contributor-list/template.hbs
+++ b/app/components/contributor-list/template.hbs
@@ -1,6 +1,8 @@
 <tbody>
   {{#each contributorList as |c|}}
-    <tr role="button" class={{if (is-current-user c.contributor) "current-user"}} {{action "openContributorDetails" c.contributor}}>
+    <tr role="button"
+        class="{{if (is-current-user c.contributor) "current-user"}} {{if (eq c.contributor.id selectedContributorId) "selected"}}"
+        {{action "openContributorDetails" c.contributor}}>
       <td class="person">
         {{user-avatar contributor=c.contributor}} {{c.contributor.name}}
       </td>

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -7,6 +7,7 @@ export default Controller.extend({
   kredits: service(),
 
   showDetailsPane: false,
+  selectedContributorId: null,
 
   currentBlock: alias('kredits.currentBlock'),
 

--- a/app/routes/dashboard/contributors/show.js
+++ b/app/routes/dashboard/contributors/show.js
@@ -11,14 +11,22 @@ export default Route.extend({
     return this.contributors.findBy('id', params.id);
   },
 
-  activate () {
+  setupController (controller, model) {
+    this._super(controller, model);
+
     this.controllerFor('dashboard')
-        .set('showDetailsPane', true);
+        .setProperties({
+          showDetailsPane: true,
+          selectedContributorId: model.id
+        });
   },
 
   deactivate () {
     this.controllerFor('dashboard')
-        .set('showDetailsPane', false);
+        .setProperties({
+          showDetailsPane: false,
+          selectedContributorId: null
+        });
   }
 
 });

--- a/app/styles/components/_contributor-list.scss
+++ b/app/styles/components/_contributor-list.scss
@@ -14,46 +14,6 @@ table.contributor-list {
       background-color: rgba(255,255,255,0.2);
     }
 
-    &.metadata {
-      height: 0;
-      visibility: hidden;
-
-      &:not(.visible) {
-        border-bottom: none;
-      }
-
-      td {
-        padding: 0 1.2rem;
-      }
-
-      a {
-        color: $primary-color;
-        &:hover, &:active {
-          color: #fff;
-        }
-      }
-
-      ul {
-        list-style: none;
-        display: block;
-        overflow: hidden;
-        height: 0;
-
-        li {
-          display: inline;
-          &+li {
-            margin-left: 1rem;
-          }
-        }
-      }
-
-      &.visible {
-        height: auto;
-        visibility: visible;
-        ul {
-          height: auto;
-        }
-      }
     }
 
     td {

--- a/app/styles/components/_contributor-list.scss
+++ b/app/styles/components/_contributor-list.scss
@@ -4,16 +4,20 @@ table.contributor-list {
   margin-bottom: 1.5rem;
 
   tr {
+    background-color: rgba(255,255,255,0.1);
     border-bottom: 1px solid rgba(255,255,255,0.2);
+    cursor: pointer;
+
     &:first-of-type {
       border-top: 1px solid rgba(255,255,255,0.2);
     }
-    background-color: rgba(255,255,255,0.1);
 
-    &.current-user {
+    &.selected {
       background-color: rgba(255,255,255,0.2);
     }
 
+    &.current-user {
+      font-weight: 500;
     }
 
     td {
@@ -31,19 +35,16 @@ table.contributor-list {
 
       &.kredits {
         text-align: right;
+
         .amount {
           font-size: 1.2rem;
           font-weight: 500;
         }
+
         .symbol {
           font-size: 0.8rem;
           padding-left: 0.2rem;
         }
-      }
-
-      pre {
-        line-height: 1rem;
-        padding-bottom: 1rem;
       }
     }
   }

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -12,7 +12,8 @@
       </header>
       <div class="content">
         {{contributor-list contributorList=kreditsToplist
-                           showUnconfirmedKredits=showUnconfirmedKredits}}
+                           showUnconfirmedKredits=showUnconfirmedKredits
+                           selectedContributorId=selectedContributorId}}
 
         <p class="stats">
           <span class="number">{{await kredits.totalKreditsEarned}}</span> kredits confirmed and issued to


### PR DESCRIPTION
Marks and unmarks the selected contributor in the list. Also changes the current user to just show as bolder font than the rest (because the selected user now has the light background). Cursor is now also adjusted to be a pointer, so it's visible that one can click the list entries.

![screencap gif](https://user-images.githubusercontent.com/842/61134475-fc4b1a80-a4bf-11e9-87df-773a277368e3.gif)
