### PR TITLE
Documentation for IPFS and Metamask

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ These are the basic steps to get up and running:
 
 #### 1. IPFS
 
-Run a local IPFS deamon in offline mode.
+Run a local IPFS deamon.
 
   * Make sure CORS headers are configured. See [IPFS](#ipfs) for more info.
-  * `ipfs daemon --offline`
+  * `ipfs daemon`
 
 #### 2. kredits-contracts
 
@@ -108,6 +108,7 @@ Install IPFS with your favorite package manager and run
     ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["localhost:4200"]'
     ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
     ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'
+    ipfs config Addresses.Gateway /ip4/127.0.0.1/tcp/8080
 
 ## Further Reading / Useful Links
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ If that is the case the DAO address must be provided as `KREDITS_KERNEL_ADDRESS`
   * `npm run dao:address` in the kredits-contracts repo to find your address
   * `KREDITS_KERNEL_ADDRESS=<0xYOURADDRESS> npm run start:local`
 
+#### 4. Metamask network
+
+Switch the network in Metamask to "Custom RPC" with the RPC URL `http://localhost:7545`.
+
 #### IPFS
 
 Install IPFS with your favorite package manager and run


### PR DESCRIPTION
The IPFS daemon needs to run with a gateway, not in offline mode. I changed the readme accordingly. I also added a config statement to set the gateway port to 8080. My port was set to 8081 by default.

I added a notice about using a custom network address in Metamask when using the local devchain.