### PR TITLE
Make contribution-status helper recompute

### DIFF
--- a/app/components/contribution-list/template.hbs
+++ b/app/components/contribution-list/template.hbs
@@ -33,7 +33,7 @@
   {{#each contributionsFiltered as |contribution|}}
     <li role="button" {{action "openContributionDetails" contribution}}
         data-contribution-id={{contribution.id}}
-        class="{{contribution-status contribution}}{{if contribution.vetoed " vetoed"}}{{if (eq contribution.id selectedContributionId) " selected"}}">
+        class="{{contribution-status contribution}}{{if (eq contribution.id selectedContributionId) " selected"}}">
       <p class="meta">
         <span class="recipient">{{user-avatar contributor=contribution.contributor}}</span>
         <span class="category {{contribution.kind}}">({{contribution.kind}})</span>

--- a/app/helpers/contribution-status.js
+++ b/app/helpers/contribution-status.js
@@ -1,6 +1,7 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
+import { once } from '@ember/runloop';
 
 export default Helper.extend({
 
@@ -8,6 +9,8 @@ export default Helper.extend({
   currentBlock: alias('kredits.currentBlock'),
 
   compute([contribution]) {
+    this.setupRecompute(contribution);
+
     if (contribution.vetoed) {
       return 'vetoed';
     } else if (contribution.confirmedAt > this.currentBlock) {
@@ -15,6 +18,31 @@ export default Helper.extend({
     } else {
       return 'confirmed'
     }
+  },
+
+  destroy () {
+    if (this.teardown) this.teardown();
+    this._super(...arguments);
+  },
+
+  setupRecompute (contribution) {
+    if (this.teardown) this.teardown();
+
+    contribution.addObserver('vetoed' , this, this.triggerRecompute);
+    contribution.addObserver('confirmedAt' , this, this.triggerRecompute);
+    contribution.addObserver('currentBlock' , this, this.triggerRecompute);
+
+    this.teardown = () => {
+      contribution.removeObserver('vetoed', this, this.triggerRecompute);
+      contribution.removeObserver('confirmedAt', this, this.triggerRecompute);
+      contribution.removeObserver('currentBlock', this, this.triggerRecompute);
+    };
+  },
+
+  triggerRecompute () {
+    once(this, function () {
+      this.recompute();
+    });
   }
 
 });


### PR DESCRIPTION
When any of the depending properties of the contribution changes, the helper recomputes its output.