### PR TITLE
Add copy/re-submit button to all contribution details

### DIFF
--- a/app/templates/dashboard/contributions/show.hbs
+++ b/app/templates/dashboard/contributions/show.hbs
@@ -50,6 +50,7 @@
 
   <div class="actions">
     <p>
+      {{link-to "Copy & edit as new" "contributions.resubmit" model class="button small"}}.
       {{#if model.ipfsHash}}
         <a href="{{ipfsGatewayUrl}}/{{model.ipfsHash}}"
            class="button small" target="_blank" rel="noopener">


### PR DESCRIPTION
We can in fact just use the exact same re-submission as we use for vetoed contributions. So all that is needed is a new button in the UI.

closes #161