### PR TITLE
Reset iOS button styling

### DIFF
--- a/app/styles/_buttons.scss
+++ b/app/styles/_buttons.scss
@@ -10,6 +10,7 @@ button, input[type=submit], .button {
   text-transform: uppercase;
   cursor: pointer;
   letter-spacing: 0.1em;
+  -webkit-appearance: none;
 
   &+button, &+input[type=submit], &+.button {
     margin-left: 0.5rem;


### PR DESCRIPTION
I noticed on iOS, the buttons were pill shaped and shaded:

![ios_veto](https://user-images.githubusercontent.com/843/69882613-118adf00-12d1-11ea-84d5-1da17017d55b.png)


This PR resets that styling so it looks the same as everywhere else:

![ios_veto_fixed](https://user-images.githubusercontent.com/843/69882634-1f406480-12d1-11ea-919c-9219e2e9aa33.png)