### PR TITLE
Show contributor/contribution details on mobile

### DIFF
--- a/app/styles/components/_contribution-details.scss
+++ b/app/styles/components/_contribution-details.scss
@@ -86,12 +86,15 @@ section#contribution-details {
   }
 }
 
-// On small screens, hide contributor and contributions list when
+// On small screens, hide intro text, contributor and contributions list when
 // showing details
 @include media-max(small) {
   #dashboard.with-details {
     #contributions, #stats {
       display: none;
     }
+  }
+  #intro.with-details {
+    display: none;
   }
 }

--- a/app/styles/components/_contribution-details.scss
+++ b/app/styles/components/_contribution-details.scss
@@ -84,5 +84,14 @@ section#contribution-details {
       }
     }
   }
+}
 
+// On small screens, hide contributor and contributions list when
+// showing details
+@include media-max(small) {
+  #dashboard.with-details {
+    #contributions, #stats {
+      display: none;
+    }
+  }
 }

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -1,5 +1,5 @@
 {{#if showIntroText}}
-  <div id="intro">
+  <div id="intro" class={{if showDetailsPane "with-details"}}>
     <h2>
       Welcome to the contribution dashboard of the
       <a href="https://kosmos.org" target="_blank" rel="noopener">Kosmos</a> project!

--- a/app/templates/dashboard/contributions/show.hbs
+++ b/app/templates/dashboard/contributions/show.hbs
@@ -42,7 +42,7 @@
           kredits will be issued.
         </p>
         <p>
-          {{link-to "Re-submit contribution …" "contributions.resubmit" model class="button small green"}}.
+          {{link-to "Re-submit contribution …" "contributions.resubmit" model class="button small green"}}
         </p>
       </div>
     {{/if}}
@@ -50,7 +50,7 @@
 
   <div class="actions">
     <p>
-      {{link-to "Copy & edit as new" "contributions.resubmit" model class="button small"}}.
+      {{link-to "Copy & edit as new" "contributions.resubmit" model class="button small"}}
       {{#if model.ipfsHash}}
         <a href="{{ipfsGatewayUrl}}/{{model.ipfsHash}}"
            class="button small" target="_blank" rel="noopener">


### PR DESCRIPTION
On small screens, when selecting a contribution or contributor, the lists are hidden and only the details are shown.

This replaces #167, removing the transition animation using liquid-fire.