### PR TITLE
Improve data sync

### DIFF
--- a/app/components/contribution-list/template.hbs
+++ b/app/components/contribution-list/template.hbs
@@ -29,7 +29,7 @@
   </div>
 {{/if}}
 
-<ul class="contribution-list">
+<ul class="contribution-list {{if @loading 'loading'}}">
   {{#each this.contributionsFiltered as |contribution|}}
     <li role="button" data-contribution-id={{contribution.id}}
         {{action "openContributionDetails" contribution}}

--- a/app/components/contributor-list/component.js
+++ b/app/components/contributor-list/component.js
@@ -2,11 +2,9 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
 export default Component.extend({
+  tagName: '',
 
   router: service(),
-
-  tagName: 'table',
-  classNames: 'contributor-list',
 
   selectedContributorId: null,
 
@@ -17,5 +15,4 @@ export default Component.extend({
     }
 
   }
-
 });

--- a/app/components/contributor-list/template.hbs
+++ b/app/components/contributor-list/template.hbs
@@ -1,21 +1,25 @@
-<tbody>
-  {{#each @contributorList as |c|}}
-    <tr role="button"
-        onclick={{action "openContributorDetails" c.contributor}}
-        class="{{if (is-current-user c.contributor) "current-user"}} {{if (eq c.contributor.id @selectedContributorId) "selected"}}">
-      <td class="person">
-        <UserAvatar @contributor={{c.contributor}} /> {{c.contributor.name}}
-      </td>
-      <td class="kredits">
-        <span class="amount">
-          {{#if @showUnconfirmedKredits}}
-            {{c.amountTotal}}
-          {{else}}
-            {{c.amountConfirmed}}
-          {{/if}}
-        </span>
-        <span class="symbol">₭S</span>
-      </td>
-    </tr>
-  {{/each}}
-</tbody>
+<table class="contributor-list {{if @loading 'loading'}}">
+  <thead>
+  </thead>
+  <tbody>
+    {{#each @contributorList as |c|}}
+      <tr role="button"
+          onclick={{action "openContributorDetails" c.contributor}}
+          class="{{if (is-current-user c.contributor) "current-user"}} {{if (eq c.contributor.id @selectedContributorId) "selected"}}">
+        <td class="person">
+          <UserAvatar @contributor={{c.contributor}} /> {{c.contributor.name}}
+        </td>
+        <td class="kredits">
+          <span class="amount">
+            {{#if @showUnconfirmedKredits}}
+              {{c.amountTotal}}
+            {{else}}
+              {{c.amountConfirmed}}
+            {{/if}}
+          </span>
+          <span class="symbol">₭S</span>
+        </td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -32,6 +32,8 @@ export default Route.extend({
           schedule('afterRender', this.kredits.syncContributions,
                    this.kredits.syncContributions.perform);
         }
+        schedule('afterRender', this.kredits.fetchAllContributions,
+                 this.kredits.fetchAllContributions.perform);
       });
   }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -32,8 +32,8 @@ export default Route.extend({
           schedule('afterRender', this.kredits.syncContributions,
                    this.kredits.syncContributions.perform);
         }
-        schedule('afterRender', this.kredits.fetchAllContributions,
-                 this.kredits.fetchAllContributions.perform);
+        schedule('afterRender', this.kredits.fetchMissingContributions,
+                 this.kredits.fetchMissingContributions.perform);
       });
   }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -25,9 +25,11 @@ export default Route.extend({
       })
       .then(() => {
         if (this.kredits.contributorsNeedFetch) {
-          schedule('afterRender', this.kredits, this.kredits.fetchContributors);
+          schedule('afterRender', this.kredits.syncContributors,
+                   this.kredits.syncContributors.perform);
         }
-        schedule('afterRender', this.kredits, this.kredits.fetchContributions);
+        schedule('afterRender', this.kredits.syncContributions,
+                 this.kredits.syncContributions.perform);
       });
   }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -24,12 +24,14 @@ export default Route.extend({
         this.kredits.addContractEventHandlers();
       })
       .then(() => {
-        if (this.kredits.contributorsNeedFetch) {
+        if (this.kredits.contributorsNeedSync) {
           schedule('afterRender', this.kredits.syncContributors,
                    this.kredits.syncContributors.perform);
         }
-        schedule('afterRender', this.kredits.syncContributions,
-                 this.kredits.syncContributions.perform);
+        if (this.kredits.contributionsNeedSync) {
+          schedule('afterRender', this.kredits.syncContributions,
+                   this.kredits.syncContributions.perform);
+        }
       });
   }
 });

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -352,7 +352,7 @@ export default Service.extend({
     }
   }),
 
-  fetchAllContributions: task(function * () {
+  fetchMissingContributions: task(function * () {
     const count = yield this.kredits.Contribution.functions.contributionsCount();
     const allIds = [...Array(count+1).keys()];
     allIds.shift(); // remove first item, which is 0
@@ -373,6 +373,9 @@ export default Service.extend({
         const c = this.loadContributionFromData(data);
         yield this.browserCache.contributions.setItem(c.id.toString(), c.serialize());
         countFetched++;
+        if (countFetched % 20 === 0) {
+          console.debug(`[kredits] Fetched ${countFetched} more contributions`);
+        }
       }
     }
     console.debug(`[kredits] Cached ${countFetched} past contributions`);

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -1,6 +1,5 @@
 import ethers from 'ethers';
 import Kredits from 'kredits-contracts';
-import RSVP from 'rsvp';
 
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
@@ -90,7 +89,7 @@ export default Service.extend({
   getEthProvider () {
     let ethProvider;
 
-    return new RSVP.Promise(async (resolve) => {
+    return new Promise(async (resolve) => {
       function instantiateWithoutAccount () {
         console.debug('[kredits] Creating new instance from npm module class');
         console.debug(`[kredits] providerURL: ${config.web3ProviderUrl}`);
@@ -323,14 +322,14 @@ export default Service.extend({
 
   getCurrentUser: computed('kredits.provider', 'currentUserAccounts.[]', function() {
     if (isEmpty(this.currentUserAccounts)) {
-      return RSVP.resolve();
+      return Promise.resolve();
     }
     return this.kredits.Contributor
       .functions.getContributorIdByAddress(this.currentUserAccounts.firstObject)
       .then((id) => {
         // check if the user is a contributor or not
         if (id === 0) {
-          return RSVP.resolve();
+          return Promise.resolve();
         } else {
           return this.kredits.Contributor.getById(id);
         }

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -94,7 +94,7 @@ export default Service.extend({
   getEthProvider () {
     let ethProvider;
 
-    return new Promise(async (resolve) => {
+    return new Promise(resolve => {
       function instantiateWithoutAccount () {
         console.debug('[kredits] Creating new instance from npm module class');
         console.debug(`[kredits] providerURL: ${config.web3ProviderUrl}`);

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -22,7 +22,6 @@ import Contribution from 'kredits-web/models/contribution'
 export default Service.extend({
 
   browserCache: service(),
-  contributorsNeedFetch: false,
 
   currentBlock: null,
   currentUserAccounts: null, // default to not having an account. this is the wen web3 is loaded.
@@ -34,6 +33,10 @@ export default Service.extend({
   currentUserIsContributor: notEmpty('currentUser'),
   currentUserIsCore: alias('currentUser.isCore'),
   hasAccounts: notEmpty('currentUserAccounts'),
+
+  // When data was loaded from cache, we need to fetch updates from the network
+  contributorsNeedSync: false,
+  contributionsNeedSync: false,
 
   contributionsUnconfirmed: computed('contributions.[]', 'currentBlock', function() {
     return this.contributions.filter(contribution => {
@@ -180,7 +183,7 @@ export default Service.extend({
     const numCachedContributors = await this.browserCache.contributors.length();
     if (numCachedContributors > 0) {
       await this.loadContributorsFromCache();
-      this.set('contributorsNeedFetch', true);
+      this.set('contributorsNeedSync', true);
     } else {
       await this.fetchContributors();
     }
@@ -188,6 +191,7 @@ export default Service.extend({
     const numCachedContributions = await this.browserCache.contributions.length();
     if (numCachedContributions > 0) {
       await this.loadContributionsFromCache();
+      this.set('contributionsNeedSync', true);
     } else {
       await this.fetchContributions({ page: { size: 30 } });
     }

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -225,17 +225,21 @@ export default Service.extend({
     console.debug(`[kredits] Fetching all contributors from the network`);
     return this.kredits.Contributor.all()
       .then(contributors => {
-        return contributors.map(data => {
-          const contributor = Contributor.create(processContributorData(data));
-          const loadedContributor = this.contributors.findBy('id', contributor.id);
-          if (loadedContributor) { this.contributors.removeObject(loadedContributor); }
-          this.contributors.pushObject(contributor);
-          return contributor;
+        return contributors.forEach(data => {
+          this.loadContributorFromData(data);
+          return;
         });
       })
       .then(() => {
         return this.cacheLoadedContributors();
       });
+  },
+
+  loadContributorFromData(data) {
+    const contributor = Contributor.create(processContributorData(data));
+    const loadedContributor = this.contributors.findBy('id', contributor.id);
+    if (loadedContributor) { this.contributors.removeObject(loadedContributor); }
+    this.contributors.pushObject(contributor);
   },
 
   async cacheLoadedContributors () {
@@ -274,11 +278,7 @@ export default Service.extend({
     return this.kredits.Contribution.all(options)
       .then(contributions => {
         return contributions.map(data => {
-          const contribution = Contribution.create(processContributionData(data));
-          contribution.set('contributor', this.contributors.findBy('id', data.contributorId.toString()));
-          const loadedContribution = this.contributions.findBy('id', contribution.id);
-          if (loadedContribution) { this.contributions.removeObject(loadedContribution); }
-          this.contributions.pushObject(contribution);
+          loadContributionFromData(data);
           return contribution;
         });
       })
@@ -290,6 +290,14 @@ export default Service.extend({
           console.debug(`[kredits] Cached ${contributions.length} contributions in browser storage`);
         });
       });
+  },
+
+  loadContributionFromData(data) {
+    const contribution = Contribution.create(processContributionData(data));
+    contribution.set('contributor', this.contributors.findBy('id', data.contributorId.toString()));
+    const loadedContribution = this.contributions.findBy('id', contribution.id);
+    if (loadedContribution) { this.contributions.removeObject(loadedContribution); }
+    this.contributions.pushObject(contribution);
   },
 
   async cacheLoadedContributions () {

--- a/app/styles/_sugar.scss
+++ b/app/styles/_sugar.scss
@@ -1,0 +1,17 @@
+@mixin loading-border-top {
+  &::before {
+    display: block;
+    width: 100%;
+    height: 1px;
+    content: '';
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.2) 40%, #68d7fb 60%, rgba(255, 255, 255, 0.2));
+    background-size: 200% 200%;
+    animation: kitt 2.5s linear infinite;
+  }
+}
+
+@keyframes kitt {
+  0%{ background-position: 0% 0%}
+  50%{ background-position: 100% 0%}
+  100%{ background-position: 0% 0%}
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -88,6 +88,7 @@ section {
 
 @import "buttons";
 @import "forms";
+@import "sugar";
 
 @import "components/contribution-list";
 @import "components/contribution-details";

--- a/app/styles/components/_contribution-list.scss
+++ b/app/styles/components/_contribution-list.scss
@@ -114,4 +114,13 @@ ul.contribution-list {
     }
   }
 
+  &.loading {
+    @include loading-border-top;
+
+    li {
+      &:first-of-type {
+        border-top: none;
+      }
+    }
+  }
 }

--- a/app/styles/components/_contributor-list.scss
+++ b/app/styles/components/_contributor-list.scss
@@ -1,4 +1,5 @@
 table.contributor-list {
+  position: relative;
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1.5rem;
@@ -46,6 +47,13 @@ table.contributor-list {
           padding-left: 0.2rem;
         }
       }
+    }
+  }
+
+  &.loading {
+    @include loading-border-top;
+    &::before {
+      position: absolute;
     }
   }
 }

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -29,7 +29,8 @@
       <div class="content">
         <ContributorList @contributorList={{this.kreditsToplist}}
                          @showUnconfirmedKredits={{this.showUnconfirmedKredits}}
-                         @selectedContributorId={{this.selectedContributorId}} />
+                         @selectedContributorId={{this.selectedContributorId}}
+                         @loading={{this.kredits.syncContributors.isRunning}} />
 
         <p class="stats">
           <span class="number">{{await this.kredits.totalKreditsEarned}}</span> kredits confirmed and issued to
@@ -58,7 +59,9 @@
     {{#if this.contributionsUnconfirmed}}
       <section id="contributions-unconfirmed">
         <header class="with-nav">
-          <h2>Latest Contributions</h2>
+          <h2>
+            Latest Contributions
+          </h2>
           <nav>
             <button type="button"
                     onclick={{action "toggleQuickFilterUnconfirmed"}}
@@ -78,7 +81,8 @@
                             @vetoContribution={{action "vetoContribution"}}
                             @contractInteractionEnabled={{this.kredits.hasAccounts}}
                             @selectedContributionId={{this.selectedContributionId}}
-                            @showQuickFilter={{this.showQuickFilterUnconfirmed}} />
+                            @showQuickFilter={{this.showQuickFilterUnconfirmed}}
+                            @loading={{this.kredits.syncContributions.isRunning}}/>
         </div>
       </section>
     {{/if}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10259,6 +10259,17 @@
         "semver": "^5.4.1"
       }
     },
+    "ember-concurrency": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-1.1.7.tgz",
+      "integrity": "sha512-PtEJvB4wG8e5CEHRC9ILl2BxF6U/xlMOhfCji/x7FxNFB9M230Du86LAy+4/yOozZHyoARVuazABPUj02P+DmQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.7.3",
+        "ember-compatibility-helpers": "^1.2.0",
+        "ember-maybe-import-regenerator": "^0.1.6"
+      }
+    },
     "ember-diff-attrs": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ember-diff-attrs/-/ember-diff-attrs-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
+    "ember-concurrency": "^1.1.7",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.1",
     "ember-flatpickr": "^2.16.2",


### PR DESCRIPTION
This introduces [ember-concurrency](http://ember-concurrency.com/docs/introduction) for managing concurrent tasks, as well as task queues, etc.. The new changes improve the fetching of data in several ways:

* If data has been loaded from cache, fetch new contributions and update unconfirmed ones (to see if they were vetoed e.g.)
* Never fetch contributions again if they are confirmed and cached
* After syncing new and unconfirmed contributions, fetch/cache all missing past contributions

After merging this one, we should soon improve the dashboard further by not showing all contributions in the list by default, and also asking the user before fetching the entire history. When we have UI for that, we can then also show sync progress somewhere.