### PR TITLE
Switch from ETH/WBTC to BTC

### DIFF
--- a/app/components/add-reimbursement/component.js
+++ b/app/components/add-reimbursement/component.js
@@ -115,14 +115,14 @@ export default class AddReimbursementComponent extends Component {
   @action
   submit (e) {
     e.preventDefault();
-    if (!this.kredits.currentUser) { window.alert('You need to connect your Ethereum account first.'); return false }
+    if (!this.kredits.currentUser) { window.alert('You need to connect your RSK account first.'); return false }
     if (!this.kredits.currentUserIsCore) { window.alert('Only core contributors can submit reimbursements.'); return false }
 
     const contributor = this.contributors.findBy('id', parseInt(this.recipientId));
 
     const attributes = {
       amount: parseInt(parseFloat(this.total) * 100000000), // convert to sats
-      token: config.tokens['WBTC'],
+      token: config.tokens['BTC'],
       recipientId: parseInt(this.recipientId),
       title: `Expenses covered by ${contributor.name}`,
       description: this.description,

--- a/app/components/add-reimbursement/template.hbs
+++ b/app/components/add-reimbursement/template.hbs
@@ -12,7 +12,7 @@
   </label>
   <fieldset class="horizontal thirds total-amounts">
     <label>
-      <p class="label">Total amount (WBTC):</p>
+      <p class="label">Total amount (BTC):</p>
       <p>
         <Input @type="text"
                @placeholder="0.0015"

--- a/app/components/budget-balances/template.hbs
+++ b/app/components/budget-balances/template.hbs
@@ -10,8 +10,8 @@
     {{#each this.balances as |balance|}}
       <tr>
         <th>{{balance.token.symbol}}</th>
-        <td class="amount">{{fmt-crypto-currency balance.balance balance.token.symbol}}</td>
-        <td class="fiat-amount">~{{balance.balanceUsd}} USD</td>
+        <td class="amount">{{balance.confirmed_balance}}</td>
+        <td class="fiat-amount">~{{balance.balanceUSD}} USD</td>
       </tr>
     {{/each}}
   </tbody>

--- a/app/components/reimbursement-list/template.hbs
+++ b/app/components/reimbursement-list/template.hbs
@@ -8,7 +8,7 @@
       </p>
       <p class="token-amount">
         <span class="amount">
-          {{sats-to-btc reimbursement.amount}}</span>&#8239;<span class="symbol">WBTC</span>
+          {{sats-to-btc reimbursement.amount}}</span>&#8239;<span class="symbol">BTC</span>
       </p>
       <ul class="expense-list">
         {{#each reimbursement.expenses as |expense|}}

--- a/app/helpers/fmt-crypto-currency.js
+++ b/app/helpers/fmt-crypto-currency.js
@@ -6,10 +6,10 @@ export default helper(function fmtCryptoCurrency(params/*, hash*/) {
   const code = params[1];
 
   switch(code) {
-    case 'ETH':
+    case 'RBTC':
       fmtAmount = amount / 1000000000000000000;
       break;
-    case 'WBTC':
+    case 'BTC':
       fmtAmount = amount / 100000000;
       break;
   }

--- a/app/services/community-funds.js
+++ b/app/services/community-funds.js
@@ -1,44 +1,38 @@
-import Service from '@ember/service';
+import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { task } from 'ember-concurrency-decorators';
 import config from 'kredits-web/config/environment';
 
-const txServiceBaseUrl = `${config.gnosisSafe.txServiceHost}/api/v1/safes/${config.gnosisSafe.address}`;
-
 export default class CommunityFundsService extends Service {
+  @service exchangeRates;
+
   @tracked balancesLoaded = false;
   @tracked balances = A([]);
 
   @task
   *fetchBalances () {
-    const uri = `${txServiceBaseUrl}/balances/usd/`;
-
-    yield fetch(uri).then(res => res.json())
-      .then(res => this.processBalances(res))
+    yield fetch(config.btcBalanceAPI).then(res => res.json())
+      .then(res => {
+        return this.processBalances(res);
+      })
       .catch(err => {
         console.log(`[community-funds] Fetching balances failed:`);
         console.error(err);
       });
   }
 
-  processBalances (res) {
-    for (const balance of res) {
-      // Format and round the approximate USD value
-      const lang = navigator.language || navigator.userLanguage;
-      balance.balanceUsd = Math.round(balance.balanceUsd).toLocaleString(lang);
+  async processBalances (res) {
+    await this.exchangeRates.fetchRates();
+    // Format and round the approximate USD value
+    const lang = navigator.language || navigator.userLanguage;
+    const balanceUSD = res.confirmed_balance * this.exchangeRates.btcusd;
+    res.balanceUSD = Math.round(balanceUSD).toLocaleString(lang);
 
-      if (balance.token) {
-        // ERC20 token, has all meta data
-        this.balances.pushObject(balance);
-      } else {
-        // RBTC, missing meta data
-        this.balances.pushObject({
-          ...balance,
-          ...{ token: { name: 'RBTC', symbol: 'RBTC'} }
-        });
-      }
-    }
+    this.balances.pushObject({
+      ...res,
+      ...{ token: { name: 'BTC', symbol: 'BTC'} }
+    });
 
     this.balancesLoaded = true;
   }

--- a/app/services/community-funds.js
+++ b/app/services/community-funds.js
@@ -32,10 +32,10 @@ export default class CommunityFundsService extends Service {
         // ERC20 token, has all meta data
         this.balances.pushObject(balance);
       } else {
-        // ETH, missing meta data
+        // RBTC, missing meta data
         this.balances.pushObject({
           ...balance,
-          ...{ token: { name: 'Ether', symbol: 'ETH'} }
+          ...{ token: { name: 'RBTC', symbol: 'RBTC'} }
         });
       }
     }

--- a/app/services/exchange-rates.js
+++ b/app/services/exchange-rates.js
@@ -8,7 +8,7 @@ const bitstampBaseUrl = `${config.corsProxy}https://www.bitstamp.net/api/v2`;
 async function fetchFromBitstamp(currencyPair) {
   try {
     const res = await fetch(`${bitstampBaseUrl}/ticker/${currencyPair}/`).then(r => r.json());
-    return res.vwap; // Last 24 hours volume weighted average price
+    return parseFloat(res.vwap); // Last 24 hours volume weighted average price
   } catch(e) {
     console.error('Could not fetch exchange rate from Bitstamp:', e);
     return 0;

--- a/app/styles/components/_budget-balances.scss
+++ b/app/styles/components/_budget-balances.scss
@@ -21,15 +21,16 @@ section#funds {
     }
 
     th {
+      font-size: 1.5rem;
       text-align: left;
-      padding-right: 1.2rem;
+      padding-right: 1rem;
     }
 
     td {
       text-align: right;
 
       &.amount {
-        font-size: 1.5rem;
+        font-size: 2rem;
         padding-right: 1.2rem;
       }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -44,10 +44,7 @@ module.exports = function(environment) {
       'BTC': '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
     },
 
-    gnosisSafe: {
-      txServiceHost: 'https://safe-transaction.mainnet.gnosis.io',
-      address: '0x9CC29b8373FF92B01C1f09F31B5DD862350c167E'
-    },
+    btcBalanceAPI: 'https://api.kosmos.org/kredits/onchain_btc_balance',
 
     corsProxy: 'https://cors.5apps.com/?uri='
   };

--- a/config/environment.js
+++ b/config/environment.js
@@ -39,7 +39,9 @@ module.exports = function(environment) {
     },
 
     tokens: {
-      'WBTC': '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+      // TODO this is still the WBTC address, since contracts currently
+      // requires a token address for reimbursements
+      'BTC': '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
     },
 
     gnosisSafe: {
@@ -67,8 +69,6 @@ module.exports = function(environment) {
       protocol: 'http',
       gatewayUrl: 'http://localhost:8080/ipfs'
     };
-
-    ENV.corsProxy = 'https://cors-anywhere.herokuapp.com/';
   }
 
   if (environment === 'test') {

--- a/tests/integration/helpers/fmt-crypto-currency-test.js
+++ b/tests/integration/helpers/fmt-crypto-currency-test.js
@@ -6,15 +6,15 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Helper | fmt-crypto-currency', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it converts Wei to ETH', async function(assert) {
-    this.set('balanceETH', '500000000000000000');
-    await render(hbs`{{fmt-crypto-currency balanceETH "ETH"}}`);
+  test('it converts Wei to RBTC', async function(assert) {
+    this.set('balanceRBTC', '500000000000000000');
+    await render(hbs`{{fmt-crypto-currency balanceRBTC "RBTC"}}`);
     assert.equal(this.element.textContent.trim(), '0.5');
   });
 
-  test('it converts Satoshis to (W)BTC', async function(assert) {
-    this.set('balanceWBTC', '117214976');
-    await render(hbs`{{fmt-crypto-currency balanceWBTC "WBTC"}}`);
+  test('it converts Satoshis to BTC', async function(assert) {
+    this.set('balanceBTC', '117214976');
+    await render(hbs`{{fmt-crypto-currency balanceBTC "BTC"}}`);
     assert.equal(this.element.textContent.trim(), '1.17214976');
   });
 });


### PR DESCRIPTION
Contract-wise, we're just changing the token label for reimbursements for now because the rest is the same as for WBTC. The community funds are now shown from a new API we maintain, but can be configured to be shown from any other URL (for self-hosted endpoints).