### PR TITLE
Improve caching, fix Firefox private mode usage

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -41,7 +41,7 @@ export default Controller.extend({
 
     vetoContribution (contributionId) {
       this.kredits.veto(contributionId).then(transaction => {
-        console.debug('[controllers:index] Veto submitted to Ethereum blockhain: '+transaction.hash);
+        console.debug('[controllers:index] Veto submitted to chain: '+transaction.hash);
       });
     },
 

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -305,11 +305,11 @@ export default Service.extend({
   }),
 
   addContribution (attributes) {
-    console.debug('[kredits] add contribution', attributes);
+    console.debug('[kredits] Adding contribution', attributes);
 
-    return this.kredits.Contribution.addContribution(attributes, { gasLimit: 300000 })
+    return this.kredits.Contribution.add(attributes, { gasLimit: 300000 })
       .then(data => {
-        console.debug('[kredits] add contribution response', data);
+        console.debug('[kredits] Contribution.add response', data);
         attributes.contributor = this.contributors.findBy('id', attributes.contributorId);
         const contribution = Contribution.create(attributes);
         contribution.set('pendingTx', data);
@@ -667,12 +667,12 @@ export default Service.extend({
     });
 
     if (pendingContribution) {
-      const attributes = await this.kredits.Contribution.getById(id);
-      attributes.contributor = this.contributors.findBy('id', attributes.contributorId);
-      const newContribution = Contribution.create(attributes);
-      this.contributions.addObject(newContribution);
       this.contributions.removeObject(pendingContribution);
     }
+
+    const data = await this.kredits.Contribution.getById(id);
+    const c = this.loadContributionFromData(data);
+    await this.browserCache.contributions.setItem(c.id.toString(), c.serialize());
   },
 
   handleContributionVetoed (contributionId) {

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -675,14 +675,15 @@ export default Service.extend({
     await this.browserCache.contributions.setItem(c.id.toString(), c.serialize());
   },
 
-  handleContributionVetoed (contributionId) {
+  async handleContributionVetoed (contributionId) {
     console.debug('[kredits] ContributionVetoed event received for ', contributionId);
-    const contribution = this.contributions.findBy('id', contributionId);
-    console.debug('[kredits] contribution', contribution);
+    const c = this.contributions.findBy('id', contributionId);
 
-    if (contribution) {
-      contribution.set('vetoed', true);
-      contribution.set('pendingTx', null);
+    if (c) {
+      console.debug('[kredits] Updating contribution', c);
+      c.set('vetoed', true);
+      c.set('pendingTx', null);
+      await this.browserCache.contributions.setItem(c.id.toString(), c.serialize());
     }
   },
 

--- a/app/utils/process-contribution-data.js
+++ b/app/utils/process-contribution-data.js
@@ -1,4 +1,4 @@
-export default function processContributionData(data) {
+export default function processContributionData(data, options={}) {
   const processed = {}
 
   if (data.confirmedAtBlock && (typeof data.confirmedAtBlock.toNumber === 'function')) {
@@ -9,12 +9,16 @@ export default function processContributionData(data) {
 
   const otherProperties = [
     'id', 'contributorId', 'amount', 'vetoed', 'ipfsHash', 'kind',
-    'description', 'details', 'url', 'date', 'time', 'pendingTx'
+    'description', 'url', 'date', 'time', 'pendingTx'
   ];
 
   otherProperties.forEach(prop => {
     processed[prop] = data[prop];
   });
+
+  if (options.includeDetails) {
+    processed.details = data.details;
+  }
 
   return processed;
 }

--- a/tests/unit/utils/process-contribution-data-test.js
+++ b/tests/unit/utils/process-contribution-data-test.js
@@ -4,16 +4,18 @@ import testData from '../../fixtures/contribution-data';
 
 module('Unit | Utility | process-contribution-data', function() {
 
-  let result = processContributionData(testData);
-
   test('formats the data correctly', function(assert) {
+    const result = processContributionData(testData);
+
     assert.ok(typeof result.confirmedAt === 'number');
   });
 
   test('copies other properties', function(assert) {
+    const result = processContributionData(testData);
+
     [
       'id', 'contributorId', 'amount', 'vetoed',
-      'ipfsHash', 'kind', 'description', 'details',
+      'ipfsHash', 'kind', 'description',
       'url', 'date', 'time', 'pendingTx'
     ].forEach(p => {
       assert.ok(Object.prototype.hasOwnProperty.call(result, p), `copies property ${p}`);
@@ -21,8 +23,17 @@ module('Unit | Utility | process-contribution-data', function() {
   });
 
   test('does not copy unnecessary properties', function(assert) {
+    const result = processContributionData(testData);
+
     ['exists', '5'].forEach(p => {
       assert.notOk(Object.prototype.hasOwnProperty.call(result, p));
     })
   });
+
+  test('includeDetails option', function(assert) {
+    const result = processContributionData(testData, { includeDetails: true });
+
+    assert.ok(Object.prototype.hasOwnProperty.call(result, 'details'), 'includes the details property/value');
+  });
+
 });


### PR DESCRIPTION
I ran into quota exceeded errors in Firefox in private mode, which this PR fixes by not storing the extended details in the browser cache. Also, it was unnecessary to keep that data in memory in the first place. (We're not currently using any of the details in the UI, and we can easily re-fetch them from IPFS later).

Includes some other caching and event listening improvements. See commits.