### PR TITLE
Make full data sync optional, start via button

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import { alias, not, sort } from '@ember/object/computed';
+import { alias, gt, not, sort } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
@@ -32,6 +32,8 @@ export default Controller.extend({
 
   showQuickFilterUnconfirmed: false,
   showQuickFilterConfirmed: false,
+
+  showFullContributionSync: gt('kredits.missingHistoricContributionsCount', 0),
 
   showIntroText: computed('kredits.{hasAccounts,currentUser}', function(){
     return (!this.kredits.hasAccounts || !this.kredits.currentUser);

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -11,8 +11,11 @@ export default class DashboardRoute extends Route {
       schedule('afterRender', this.kredits.syncContributions,
         this.kredits.syncContributions.perform);
     }
-    schedule('afterRender', this.kredits.fetchMissingContributions,
-      this.kredits.fetchMissingContributions.perform);
+    // TODO fetch automatically under a certain threshold
+    // The browser might delete cached data and we don't need manual re-syncs
+    // depending on how little is missing
+    // schedule('afterRender', this.kredits.fetchMissingContributions,
+    //   this.kredits.fetchMissingContributions.perform);
   }
 
 }

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -105,6 +105,32 @@
                           @showQuickFilter={{this.showQuickFilterConfirmed}} />
       </div>
     </section>
+
+    {{#if this.showFullContributionSync}}
+    <section id="sync-all-contributions">
+      {{#if this.kredits.fetchMissingContributions.isIdle}}
+        <p style="margin-bottom: 1rem;">
+          There are
+          <strong>{{this.kredits.missingHistoricContributionsCount}}</strong>
+          contributions, which are not currently loaded/displayed.
+        </p>
+        <p>
+          You can fetch all historic data in one go, and have it stored locally in
+          your browser:
+          <button type="button" {{on "click" (perform this.kredits.fetchMissingContributions)}} class="small">
+            fetch all data
+          </button>
+        </p>
+      {{else}}
+        <p style="margin-bottom: 1rem;">
+          Syncing data. Please be patient...
+        </p>
+        <p>
+          (You can leave this website anytime and sync missing data when you come back.)
+        </p>
+      {{/if}}
+    </section>
+    {{/if}}
   </div>
 
   <div id="details">


### PR DESCRIPTION
The UI isn't great yet, just some text and a button at the end of the last contribution list. But I think it's already better to load historic data manually with this, instead of starting a full sync whenever someone loads the app without all historic data already in cache.