### PR TITLE
Fix timezone issue in expense item form

### DIFF
--- a/app/components/add-expense-item/component.js
+++ b/app/components/add-expense-item/component.js
@@ -63,7 +63,10 @@ export default class AddExpenseItemComponent extends Component {
 
     let dateInput = (this.date instanceof Array) ?
       this.date[0] : this.date;
-    const [ date ] = dateInput.toISOString().split('T');
+
+    const [ date ] = moment(dateInput).utcOffset(0, true)
+                                      .toISOString()
+                                      .split('T');
 
     const isValid = this.validateForm();
     if (!isValid) return false;


### PR DESCRIPTION
Dates being added with 00:00 time still carry the timezone set for the OS/browser, and thus get changed to the previous day when in a positive offset zone. This change removes the timezone offset entirely when adding the line item, so that the chosen date is always assumed to be in UTC time.

fixes #204