### PR TITLE
Expense list UI improvements

### DIFF
--- a/app/components/add-reimbursement/template.hbs
+++ b/app/components/add-reimbursement/template.hbs
@@ -44,26 +44,10 @@
 
   <h3>Expense items</h3>
   {{#if this.expenses}}
-    <ul class="expense-list">
-      {{#each this.expenses as |expense|}}
-        <li>
-          <div class="description" rowspan="2">
-            <h4>
-              <span class="date">{{expense.date}}:</span>
-              <span class="title">{{expense.title}}</span>
-            </h4>
-            <p class="description">{{expense.description}}</p>
-          </div>
-          <div class="amount">
-            {{fmt-fiat-currency expense.amount expense.currency}}
-          </div>
-          <div class="actions">
-            <button {{on "click" (fn this.removeExpenseItem expense)}}
-              class="danger small" type="button">delete</button>
-          </div>
-        </li>
-      {{/each}}
-    </ul>
+     <ExpenseList @expenses={{this.expenses}}
+                  @removeExpenseItem={{this.removeExpenseItem}}
+                  @deletable=yes />
+
     <p class="actions">
       <button {{on "click" this.showExpenseForm}}
         class="green small" type="button">+ Add another item</button>

--- a/app/components/add-reimbursement/template.hbs
+++ b/app/components/add-reimbursement/template.hbs
@@ -46,7 +46,7 @@
   {{#if this.expenses}}
      <ExpenseList @expenses={{this.expenses}}
                   @removeExpenseItem={{this.removeExpenseItem}}
-                  @deletable=yes />
+                  @deletable={{true}} />
 
     <p class="actions">
       <button {{on "click" this.showExpenseForm}}

--- a/app/components/expense-list/component.js
+++ b/app/components/expense-list/component.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class ExpenseListComponent extends Component {
+
+  get showDeleteButton () {
+    return !!this.args.deletable;
+  }
+
+}

--- a/app/components/expense-list/template.hbs
+++ b/app/components/expense-list/template.hbs
@@ -1,0 +1,27 @@
+<ul class="expense-list">
+  {{#each @expenses as |expense|}}
+    <li class="expense-item">
+      <h4>
+        <span class="date">{{expense.date}}:</span>
+        <span class="title">{{expense.title}}</span>
+      </h4>
+      <div class="amount">
+        {{fmt-fiat-currency expense.amount expense.currency}}
+      </div>
+      <p class="description">
+        {{expense.description}}
+      </p>
+      <p class="tags">
+        {{#each expense.tags as |tag|}}
+          <button class="small" role="none">{{tag}}</button>
+        {{/each}}
+      </p>
+      {{#if this.showDeleteButton}}
+        <div class="actions">
+          <button {{on "click" (fn @removeExpenseItem expense)}}
+            class="danger small" type="button">delete</button>
+        </div>
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/app/components/expense-list/template.hbs
+++ b/app/components/expense-list/template.hbs
@@ -2,7 +2,7 @@
   {{#each @expenses as |expense|}}
     <li class="expense-item">
       <h4>
-        <span class="date">{{expense.date}}:</span>
+        <span class="date">{{fmt-date-localized expense.date}}:</span>
         <span class="title">{{expense.title}}</span>
       </h4>
       <div class="amount">

--- a/app/components/expense-list/template.hbs
+++ b/app/components/expense-list/template.hbs
@@ -13,7 +13,9 @@
       </p>
       <p class="tags">
         {{#each expense.tags as |tag|}}
-          <button class="small" role="none">{{tag}}</button>
+          <button class="small yellow" role="none">
+            <IconTag />{{tag}}
+          </button>
         {{/each}}
       </p>
       {{#if this.showDeleteButton}}

--- a/app/components/reimbursement-list/template.hbs
+++ b/app/components/reimbursement-list/template.hbs
@@ -14,22 +14,9 @@
         <span class="amount">
           {{sats-to-btc reimbursement.amount}}</span>&#8239;<span class="symbol">BTC</span>
       </p>
-      <ul class="expense-list">
-        {{#each reimbursement.expenses as |expense|}}
-          <li>
-            <div class="description" rowspan="2">
-              <h4>
-                <span class="date">{{expense.date}}:</span>
-                <span class="title">{{expense.title}}</span>
-              </h4>
-              <p class="description">{{expense.description}}</p>
-            </div>
-            <div class="amount">
-              {{fmt-fiat-currency expense.amount expense.currency}}
-            </div>
-          </li>
-        {{/each}}
-      </ul>
+
+      <ExpenseList @expenses={{reimbursement.expenses}} />
+
       <div class="meta">
         <p class="confirmation-eta">
           <ConfirmedIn @confirmedAtBlock={{reimbursement.confirmedAt}} />

--- a/app/helpers/fmt-date-localized.js
+++ b/app/helpers/fmt-date-localized.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import getLocale from 'kredits-web/utils/get-locale';
+
+export default helper(function(dateStr) {
+  const date = new Date(dateStr);
+  const locale = getLocale();
+  return new Intl.DateTimeFormat(locale).format(date);
+});

--- a/app/styles/_buttons.scss
+++ b/app/styles/_buttons.scss
@@ -31,32 +31,53 @@ button, input[type=submit], .button {
   &.small {
     font-size: 0.86rem;
     padding: 0.2rem 0.8rem;
+
+    svg {
+      width: 1em;
+      height: 1em;
+      vertical-align: middle;
+      margin-right: 0.4rem;
+    }
   }
 
   &.danger:not(:disabled) {
     color: $red;
     background-color: rgba(40, 21, 21, 0.6);
     border-color: rgba(40, 21, 21, 1);
-
-    &:hover {
-      background-color: rgba(40, 21, 21, 0.8);
-    }
-    &:focus, &:active, &.active {
-      border-color: $red;
-    }
+    &:hover { background-color: rgba(40, 21, 21, 0.8); }
+    &:focus, &:active, &.active { border-color: $red; }
   }
 
   &.green:not(:disabled) {
     color: $green;
     background-color: rgba(21, 40, 21, 0.6);
     border-color: rgba(21, 40, 21, 1);
+    &:hover { background-color: rgba(21, 40, 21, 0.8); }
+    &:focus, &:active, &.active { border-color: $green; }
+  }
 
-    &:hover {
-      background-color: rgba(21, 40, 21, 0.8);
-    }
-    &:focus, &:active, &.active {
-      border-color: $green;
-    }
+  &.pink:not(:disabled) {
+    color: $pink;
+    background-color: rgba(40, 21, 40, 0.6);
+    border-color: rgba(40, 21, 40, 1);
+    &:hover { background-color: rgba(40, 21, 40, 0.8); }
+    &:focus, &:active, &.active { border-color: $pink; }
+  }
+
+  &.purple:not(:disabled) {
+    color: $purple;
+    background-color: rgba(24, 21, 40, 0.6);
+    border-color: rgba(24, 21, 40, 1);
+    &:hover { background-color: rgba(24, 21, 40, 0.8); }
+    &:focus, &:active, &.active { border-color: $purple; }
+  }
+
+  &.yellow:not(:disabled) {
+    color: $yellow;
+    background-color: rgba(40, 40, 21, 0.6);
+    border-color: rgba(40, 40, 21, 1);
+    &:hover { background-color: rgba(40, 40, 21, 0.8); }
+    &:focus, &:active, &.active { border-color: $yellow; }
   }
 
   &.icon {

--- a/app/styles/components/_expense-list.scss
+++ b/app/styles/components/_expense-list.scss
@@ -17,32 +17,30 @@ ul.expense-list {
     }
   }
 
-  .description {
-    grid-row-start: 1;
-    grid-row-end: 3;
-  }
-
-  .amount {
-    justify-self: end;
-    // font-weight: normal;
-  }
-
-  .actions {
-    justify-self: end;
-  }
-
   h4 {
     font-size: 1.2rem;
     font-weight: normal;
     line-height: 2rem;
   }
 
-  p {
-    line-height: 2rem;
+  .amount {
+    justify-self: end;
+  }
 
-    &.description {
-      font-size: 1rem;
-      opacity: 0.7;
+  .description {
+    font-size: 1rem;
+    opacity: 0.7;
+    grid-column-start: span 2;
+  }
+
+  .tags {
+    button {
+      margin-left: 0;
     }
   }
+
+  .actions {
+    justify-self: end;
+  }
+
 }

--- a/app/templates/components/icon-tag.hbs
+++ b/app/templates/components/icon-tag.hbs
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-tag"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path><line x1="7" y1="7" x2="7.01" y2="7"></line></svg>

--- a/app/utils/get-locale.js
+++ b/app/utils/get-locale.js
@@ -1,0 +1,5 @@
+export default function() {
+  return (navigator.languages && navigator.languages.length) ?
+    navigator.languages[0] :
+    navigator.language;
+}


### PR DESCRIPTION
* Add expense list component and DRY up the code
* Add tags
* Localize dates
* Improve UI, esp. on small screens

Example of normal expense list (in reimbursement list):

![Screenshot from 2023-01-13 15-41-38](https://user-images.githubusercontent.com/842/212265502-8cd4501b-1c52-4756-a7b8-107d8dac4996.png)

Example of expense list in the reimbursement form:

![Screenshot from 2023-01-13 15-42-25](https://user-images.githubusercontent.com/842/212265581-07c657fd-42e6-4391-87f1-ef6aa076b29b.png)
