### PR TITLE
Fix dashboard hanging when loading app from contributor URL

### DIFF
--- a/app/routes/dashboard/contributors/show.js
+++ b/app/routes/dashboard/contributors/show.js
@@ -8,7 +8,13 @@ export default Route.extend({
   contributors: alias('kredits.contributors'),
 
   model (params) {
-    return this.contributors.findBy('id', params.id);
+    const contributor = this.contributors.findBy('id', params.id);
+
+    if (contributor) {
+      return contributor;
+    } else {
+      return this.kredits.fetchContributor(params.id);
+    }
   },
 
   setupController (controller, model) {

--- a/app/services/kredits.js
+++ b/app/services/kredits.js
@@ -274,6 +274,12 @@ export default Service.extend({
       });
   },
 
+  async fetchContributor (id) {
+    console.debug(`[kredits] Fetching contributor from the network`);
+    return this.kredits.Contributor.getById(id)
+      .then(data => this.loadContributorFromData(data))
+  },
+
   fetchContributors () {
     console.debug(`[kredits] Fetching all contributors from the network`);
     return this.kredits.Contributor.all()


### PR DESCRIPTION
Loading the app from /dashboard/contributors/:id is failing, because the contributors are loaded later. This fetches the requested contributor separately when launching the app from a contributor profile URL.