### PR TITLE
Improve reimbursement lists

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   rules: {
     'simple-unless': false,
     'no-nested-interactive': false,
+    'no-invalid-interactive': false,
     'no-html-comments': false
   },
 

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -6,7 +6,6 @@ module.exports = {
   rules: {
     'simple-unless': false,
     'no-nested-interactive': false,
-    'no-invalid-interactive': false,
     'no-html-comments': false
   },
 

--- a/app/components/confirmed-in/template.hbs
+++ b/app/components/confirmed-in/template.hbs
@@ -1,3 +1,5 @@
-{{#unless this.isConfirmed}}
+{{#if this.isConfirmed}}
+Confirmed at block <strong>{{@confirmedAtBlock}}</strong> (~ {{this.confirmedInHumanTime}} ago)
+{{else}}
 Confirming in <strong>{{this.confirmedInBlocks}}</strong> blocks (~ {{this.confirmedInHumanTime}})
-{{/unless}}
+{{/if}}

--- a/app/components/reimbursement-item/component.js
+++ b/app/components/reimbursement-item/component.js
@@ -1,10 +1,19 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import config from 'kredits-web/config/environment';
 
 export default class ReimbursementItemComponent extends Component {
   @service kredits;
+  @tracked showExpenseDetails = false;
+
+  constructor(owner, args) {
+    super(owner, args);
+    if (this.isUnconfirmed && !this.args.reimbursement.vetoed) {
+      this.showExpenseDetails = true;
+    }
+  }
 
   get ipfsGatewayUrl () {
     return config.ipfs.gatewayUrl;
@@ -20,6 +29,11 @@ export default class ReimbursementItemComponent extends Component {
 
   get showVetoButton () {
     return this.isUnconfirmed && this.kredits.currentUserIsCore;
+  }
+
+  @action
+  toggleExpenseDetails () {
+    this.showExpenseDetails = !this.showExpenseDetails;
   }
 
   @action

--- a/app/components/reimbursement-item/component.js
+++ b/app/components/reimbursement-item/component.js
@@ -14,7 +14,6 @@ export default class ReimbursementItemComponent extends Component {
     if (this.isUnconfirmed && !this.isVetoed) {
       this.showExpenseDetails = true;
     }
-    console.debug(fmtDateLocalized);
   }
 
   get ipfsGatewayUrl () {

--- a/app/components/reimbursement-item/component.js
+++ b/app/components/reimbursement-item/component.js
@@ -10,6 +10,18 @@ export default class ReimbursementItemComponent extends Component {
     return config.ipfs.gatewayUrl;
   }
 
+  get isConfirmed () {
+    return (this.args.reimbursement.confirmedAt - this.kredits.currentBlock) <= 0;
+  }
+
+  get isUnconfirmed () {
+    return !this.isConfirmed;
+  }
+
+  get showVetoButton () {
+    return this.isUnconfirmed && this.kredits.currentUserIsCore;
+  }
+
   @action
   veto (id) {
     this.kredits.vetoReimbursement(id).then(transaction => {

--- a/app/components/reimbursement-item/component.js
+++ b/app/components/reimbursement-item/component.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import config from 'kredits-web/config/environment';
+import fmtDateLocalized from 'kredits-web/helpers/fmt-date-localized';
 
 export default class ReimbursementItemComponent extends Component {
   @service kredits;
@@ -10,9 +11,10 @@ export default class ReimbursementItemComponent extends Component {
 
   constructor(owner, args) {
     super(owner, args);
-    if (this.isUnconfirmed && !this.args.reimbursement.vetoed) {
+    if (this.isUnconfirmed && !this.isVetoed) {
       this.showExpenseDetails = true;
     }
+    console.debug(fmtDateLocalized);
   }
 
   get ipfsGatewayUrl () {
@@ -27,8 +29,30 @@ export default class ReimbursementItemComponent extends Component {
     return !this.isConfirmed;
   }
 
+  get isVetoed () {
+    return this.args.reimbursement.vetoed;
+  }
+
   get showVetoButton () {
     return this.isUnconfirmed && this.kredits.currentUserIsCore;
+  }
+
+  get showConfirmedIn () {
+    return !this.isVetoed &&
+           (this.showExpenseDetails || this.isUnconfirmed);
+  }
+
+  get expenses () {
+    return this.args.reimbursement.expenses;
+  }
+
+  get expensesDateRange () {
+    const dates = this.expenses.map(e => e.date).uniq().sort();
+    let out = fmtDateLocalized.compute(dates.firstObject)
+    if (dates.length > 1) {
+      out += ' - ' + fmtDateLocalized.compute(dates.lastObject)
+    }
+    return out;
   }
 
   @action

--- a/app/components/reimbursement-item/component.js
+++ b/app/components/reimbursement-item/component.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import config from 'kredits-web/config/environment';
+
+export default class ReimbursementItemComponent extends Component {
+  @service kredits;
+
+  get ipfsGatewayUrl () {
+    return config.ipfs.gatewayUrl;
+  }
+
+  @action
+  veto (id) {
+    this.kredits.vetoReimbursement(id).then(transaction => {
+      console.debug('[controllers:budget] Veto submitted to chain: '+transaction.hash);
+    });
+  }
+}

--- a/app/components/reimbursement-item/template.hbs
+++ b/app/components/reimbursement-item/template.hbs
@@ -24,7 +24,7 @@
          class="button small" target="_blank" rel="noopener noreferrer">
         Inspect IPFS data
       </a>
-      {{#if this.kredits.currentUserIsCore}}
+      {{#if this.showVetoButton}}
         <button {{on "click" (fn this.veto @reimbursement.id)}}
                 disabled={{@reimbursement.vetoed}}
                 class="button small danger" type="button">veto</button>

--- a/app/components/reimbursement-item/template.hbs
+++ b/app/components/reimbursement-item/template.hbs
@@ -1,0 +1,34 @@
+<li data-reimbursement-id={{@reimbursement.id}}
+    class="{{item-status @reimbursement}}">
+  <p class="meta">
+    <span class="recipient">
+      <UserAvatar @contributor={{@reimbursement.contributor}} />
+    </span>
+    <span class="title">
+      Expenses covered by {{@reimbursement.contributor.name}}
+    </span>
+  </p>
+  <p class="token-amount">
+    <span class="amount">
+      {{sats-to-btc @reimbursement.amount}}</span>&#8239;<span class="symbol">BTC</span>
+  </p>
+
+  <ExpenseList @expenses={{@reimbursement.expenses}} />
+
+  <div class="meta">
+    <p class="confirmation-eta">
+      <ConfirmedIn @confirmedAtBlock={{@reimbursement.confirmedAt}} />
+    </p>
+    <p class="actions">
+      <a href="{{this.ipfsGatewayUrl}}/{{@reimbursement.ipfsHash}}"
+         class="button small" target="_blank" rel="noopener noreferrer">
+        Inspect IPFS data
+      </a>
+      {{#if this.kredits.currentUserIsCore}}
+        <button {{on "click" (fn this.veto @reimbursement.id)}}
+                disabled={{@reimbursement.vetoed}}
+                class="button small danger" type="button">veto</button>
+      {{/if}}
+    </p>
+  </div>
+</li>

--- a/app/components/reimbursement-item/template.hbs
+++ b/app/components/reimbursement-item/template.hbs
@@ -1,6 +1,6 @@
 <li data-reimbursement-id={{@reimbursement.id}}
     class="{{item-status @reimbursement}}"
-    {{on "click" this.toggleExpenseDetails}}>
+    role="button" {{on "click" this.toggleExpenseDetails}}>
   <p class="meta">
     <span class="recipient">
       <UserAvatar @contributor={{@reimbursement.contributor}} />

--- a/app/components/reimbursement-item/template.hbs
+++ b/app/components/reimbursement-item/template.hbs
@@ -19,8 +19,12 @@
   {{/if}}
 
   <div class="meta">
-    <p class="confirmation-eta">
+    <p>
+      {{#if this.showConfirmedIn}}
       <ConfirmedIn @confirmedAtBlock={{@reimbursement.confirmedAt}} />
+      {{else}}
+        {{#unless this.isVetoed}}{{this.expensesDateRange}}{{/unless}}
+      {{/if}}
     </p>
     <p class="actions">
       <a href="{{this.ipfsGatewayUrl}}/{{@reimbursement.ipfsHash}}"

--- a/app/components/reimbursement-item/template.hbs
+++ b/app/components/reimbursement-item/template.hbs
@@ -1,5 +1,6 @@
 <li data-reimbursement-id={{@reimbursement.id}}
-    class="{{item-status @reimbursement}}">
+    class="{{item-status @reimbursement}}"
+    {{on "click" this.toggleExpenseDetails}}>
   <p class="meta">
     <span class="recipient">
       <UserAvatar @contributor={{@reimbursement.contributor}} />
@@ -13,7 +14,9 @@
       {{sats-to-btc @reimbursement.amount}}</span>&#8239;<span class="symbol">BTC</span>
   </p>
 
+  {{#if this.showExpenseDetails}}
   <ExpenseList @expenses={{@reimbursement.expenses}} />
+  {{/if}}
 
   <div class="meta">
     <p class="confirmation-eta">

--- a/app/components/reimbursement-list/component.js
+++ b/app/components/reimbursement-list/component.js
@@ -1,23 +1,10 @@
 import Component from '@glimmer/component';
 import { sort } from '@ember/object/computed';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import config from 'kredits-web/config/environment';
 
 export default class ReimbursementListComponent extends Component {
   @service kredits;
 
   itemSorting = Object.freeze(['pendingStatus:asc', 'id:desc']);
   @sort('args.items', 'itemSorting') itemsSorted;
-
-  get ipfsGatewayUrl () {
-    return config.ipfs.gatewayUrl;
-  }
-
-  @action
-  veto (id) {
-    this.kredits.vetoReimbursement(id).then(transaction => {
-      console.debug('[controllers:budget] Veto submitted to chain: '+transaction.hash);
-    });
-  }
 }

--- a/app/components/reimbursement-list/template.hbs
+++ b/app/components/reimbursement-list/template.hbs
@@ -1,38 +1,5 @@
 <ul class="item-list spaced reimbursement-list {{if @loading 'loading'}}">
-  {{#each this.itemsSorted as |reimbursement|}}
-    <li data-reimbursement-id={{reimbursement.id}}
-        class="{{item-status reimbursement}}">
-      <p class="meta">
-        <span class="recipient">
-          <UserAvatar @contributor={{reimbursement.contributor}} />
-        </span>
-        <span class="title">
-          Expenses covered by {{reimbursement.contributor.name}}
-        </span>
-      </p>
-      <p class="token-amount">
-        <span class="amount">
-          {{sats-to-btc reimbursement.amount}}</span>&#8239;<span class="symbol">BTC</span>
-      </p>
-
-      <ExpenseList @expenses={{reimbursement.expenses}} />
-
-      <div class="meta">
-        <p class="confirmation-eta">
-          <ConfirmedIn @confirmedAtBlock={{reimbursement.confirmedAt}} />
-        </p>
-        <p class="actions">
-          <a href="{{this.ipfsGatewayUrl}}/{{reimbursement.ipfsHash}}"
-             class="button small" target="_blank" rel="noopener noreferrer">
-            Inspect IPFS data
-          </a>
-          {{#if this.kredits.currentUserIsCore}}
-            <button {{on "click" (fn this.veto reimbursement.id)}}
-                    disabled={{reimbursement.vetoed}}
-                    class="button small danger" type="button">veto</button>
-          {{/if}}
-        </p>
-      </div>
-    </li>
+  {{#each this.itemsSorted as |item|}}
+    <ReimbursementItem @reimbursement={{item}} />
   {{/each}}
 </ul>

--- a/app/components/reimbursement-list/template.hbs
+++ b/app/components/reimbursement-list/template.hbs
@@ -1,4 +1,4 @@
-<ul class="item-list spaced reimbursement-list {{if @loading 'loading'}}">
+<ul class="item-list collapsible spaced reimbursement-list {{if @loading 'loading'}}">
   {{#each this.itemsSorted as |item|}}
     <ReimbursementItem @reimbursement={{item}} />
   {{/each}}

--- a/app/helpers/fmt-date-localized.js
+++ b/app/helpers/fmt-date-localized.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 import getLocale from 'kredits-web/utils/get-locale';
 
-export default helper(function(dateStr) {
+export default helper(function fmtDateLocalized(dateStr) {
   const date = new Date(dateStr);
   const locale = getLocale();
   return new Intl.DateTimeFormat(locale).format(date);

--- a/app/styles/_item-list.scss
+++ b/app/styles/_item-list.scss
@@ -16,6 +16,16 @@ ul.item-list {
     }
   }
 
+  &.collapsible {
+    > li {
+      border-left: 1px solid transparent;
+
+      &:hover {
+        border-left: 1px solid $blue;
+      }
+    }
+  }
+
   &.loading {
     @include loading-border-top;
 

--- a/app/styles/components/_reimbursement-list.scss
+++ b/app/styles/components/_reimbursement-list.scss
@@ -43,9 +43,6 @@ ul.reimbursement-list {
       flex: 1;
       padding: 1.6rem 0 1rem 0;
 
-      &.confirmation-eta {
-      }
-
       &.actions {
         text-align: right;
       }


### PR DESCRIPTION
* Hide veto button for confirmed reimbursements
* Show confirmation block for confirmed reimbursements (when details visible)
* Hide expense line items by default for confirmed reimbursements, show/hide on click/tap (with hover indicator to discover)
* Show date range of line items while collapsed

![Screenshot from 2024-03-16 14-42-11](https://github.com/67P/kredits-web/assets/842/325f024c-8f94-405d-b82c-5e9547d128ce)

refs #221 